### PR TITLE
Implement Display trait for AccessFlags

### DIFF
--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -535,18 +535,22 @@ impl ToString for ByteCode {
             ByteCode::FilledNewArray(ref registers, reference) => {
                 let str_register: Vec<String> =
                     registers.iter().map(|r| format!("v{}", r)).collect();
-                format!("filled-new-array {{{}}}, type@{}",
-                        str_register.join(", "),
-                        reference)
+                format!(
+                    "filled-new-array {{{}}}, type@{}",
+                    str_register.join(", "),
+                    reference
+                )
             }
             ByteCode::FilledNewArrayRange(first_reg, amount, reference) => {
                 let str_register: Vec<String> = (first_reg..
-                                                 (first_reg as u16 + amount as u16 + 1) as u16)
-                        .map(|r| format!("v{}", r))
-                        .collect();
-                format!("filled-new-array/range {{{}}}, type@{}",
-                        str_register.join(", "),
-                        reference)
+                                                     (first_reg as u16 + amount as u16 + 1) as u16)
+                    .map(|r| format!("v{}", r))
+                    .collect();
+                format!(
+                    "filled-new-array/range {{{}}}, type@{}",
+                    str_register.join(", "),
+                    reference
+                )
             }
             ByteCode::FillArrayData(reg, offset) => format!("fill-array-data v{}, {}", reg, offset),
             ByteCode::Throw(reg) => format!("throw v{}", reg),
@@ -568,11 +572,13 @@ impl ToString for ByteCode {
                 format!("a{} v{}, v{}, v{}", array_op.to_string(), dest, op1, op2)
             }
             ByteCode::Instance(ref array_op, dest, op1, field) => {
-                format!("i{} v{}, v{}, field@{}",
-                        array_op.to_string(),
-                        dest,
-                        op1,
-                        field)
+                format!(
+                    "i{} v{}, v{}, field@{}",
+                    array_op.to_string(),
+                    dest,
+                    op1,
+                    field
+                )
             }
             ByteCode::Static(ref array_op, dest, field) => {
                 format!("s{} v{}, field@{}", array_op.to_string(), dest, field)
@@ -580,19 +586,23 @@ impl ToString for ByteCode {
             ByteCode::Invoke(ref invoke_kind, ref registers, method) => {
                 let str_register: Vec<String> =
                     registers.iter().map(|r| format!("v{}", r)).collect();
-                format!("{} {{{}}}, method@{}",
-                        invoke_kind.to_string(),
-                        str_register.join(", "),
-                        method)
+                format!(
+                    "{} {{{}}}, method@{}",
+                    invoke_kind.to_string(),
+                    str_register.join(", "),
+                    method
+                )
             }
             ByteCode::InvokeRange(ref invoke_kind, first_reg, amount, reference) => {
                 let str_register: Vec<String> = (first_reg..(first_reg + amount as u16))
                     .map(|r| format!("v{}", r))
                     .collect();
-                format!("{}/range {{{}}}, method@{}",
-                        invoke_kind.to_string(),
-                        str_register.join(", "),
-                        reference)
+                format!(
+                    "{}/range {{{}}}, method@{}",
+                    invoke_kind.to_string(),
+                    str_register.join(", "),
+                    reference
+                )
             }
             ByteCode::Unary(ref operation, dest, src) => {
                 format!("{} v{}, v{}", operation.to_string(), dest, src)
@@ -609,52 +619,64 @@ impl ToString for ByteCode {
                         format!("rsub-int v{}, v{}, #{}", dest, src, literal)
                     }
                     _ => {
-                        format!("{}/lit16 v{}, v{}, #{}",
-                                operation.to_string(),
-                                dest,
-                                src,
-                                literal)
+                        format!(
+                            "{}/lit16 v{}, v{}, #{}",
+                            operation.to_string(),
+                            dest,
+                            src,
+                            literal
+                        )
                     }
                 }
             }
             ByteCode::BinaryLit8(ref operation, dest, src, literal) => {
-                format!("{}/lit8 v{}, v{}, #{}",
-                        operation.to_string(),
-                        dest,
-                        src,
-                        literal)
+                format!(
+                    "{}/lit8 v{}, v{}, #{}",
+                    operation.to_string(),
+                    dest,
+                    src,
+                    literal
+                )
             }
             ByteCode::InvokePolymorphic(ref registers, method, proto) => {
                 let str_register: Vec<String> =
                     registers.iter().map(|r| format!("v{}", r)).collect();
-                format!("invoke-polymorphic {{{}}}, method@{} proto@{}",
-                        str_register.join(", "),
-                        method,
-                        proto)
+                format!(
+                    "invoke-polymorphic {{{}}}, method@{} proto@{}",
+                    str_register.join(", "),
+                    method,
+                    proto
+                )
             }
             ByteCode::InvokePolymorphicRange(first_reg, amount, method, proto) => {
                 let str_register: Vec<String> = (first_reg..(first_reg + amount as u16))
                     .map(|r| format!("v{}", r))
                     .collect();
-                format!("invoke-polymorphic/range {{{}}}, method@{} proto@{}",
-                        str_register.join(", "),
-                        method,
-                        proto)
+                format!(
+                    "invoke-polymorphic/range {{{}}}, method@{} proto@{}",
+                    str_register.join(", "),
+                    method,
+                    proto
+                )
             }
             ByteCode::InvokeCustom(ref registers, call_site) => {
                 let str_register: Vec<String> =
                     registers.iter().map(|r| format!("v{}", r)).collect();
-                format!("invoke-custom {{{}}}, call_site@{}",
-                        str_register.join(", "),
-                        call_site)
+                format!(
+                    "invoke-custom {{{}}}, call_site@{}",
+                    str_register.join(", "),
+                    call_site
+                )
             }
             ByteCode::InvokeCustomRange(first_reg, amount, call_site) => {
                 let str_register: Vec<String> = (first_reg..(first_reg + amount as u16))
                     .map(|r| format!("v{}", r))
                     .collect();
-                format!("invoke-custom/range {{{}}}, call_site@{}",
-                        str_register.join(", "),
-                        call_site)
+                format!(
+                    "invoke-custom/range {{{}}}, call_site@{}",
+                    str_register.join(", "),
+                    call_site
+                )
             }
         }
     }
@@ -916,36 +938,36 @@ impl<R: Read> Iterator for ByteCodeDecoder<R> {
             Ok(0x00) => self.format10x().ok().map(|_| ByteCode::Nop),
             Ok(0x01) => self.format12x().ok().map(|(d, s)| ByteCode::Move(d, s)),
             Ok(0x02) => {
-                self.format22x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveFrom16(d, s))
+                self.format22x().ok().map(
+                    |(d, s)| ByteCode::MoveFrom16(d, s),
+                )
             }
             Ok(0x03) => self.format32x().ok().map(|(d, s)| ByteCode::Move16(d, s)),
             Ok(0x04) => self.format12x().ok().map(|(d, s)| ByteCode::MoveWide(d, s)),
             Ok(0x05) => {
-                self.format22x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveWideFrom16(d, s))
+                self.format22x().ok().map(
+                    |(d, s)| ByteCode::MoveWideFrom16(d, s),
+                )
             }
             Ok(0x06) => {
-                self.format32x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveWide16(d, s))
+                self.format32x().ok().map(
+                    |(d, s)| ByteCode::MoveWide16(d, s),
+                )
             }
             Ok(0x07) => {
-                self.format12x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveObject(d, s))
+                self.format12x().ok().map(
+                    |(d, s)| ByteCode::MoveObject(d, s),
+                )
             }
             Ok(0x08) => {
-                self.format22x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveObjectFrom16(d, s))
+                self.format22x().ok().map(|(d, s)| {
+                    ByteCode::MoveObjectFrom16(d, s)
+                })
             }
             Ok(0x09) => {
-                self.format32x()
-                    .ok()
-                    .map(|(d, s)| ByteCode::MoveObject16(d, s))
+                self.format32x().ok().map(
+                    |(d, s)| ByteCode::MoveObject16(d, s),
+                )
             }
             Ok(0x0A) => self.format11x().ok().map(ByteCode::MoveResult),
             Ok(0x0B) => self.format11x().ok().map(ByteCode::MoveResultWide),
@@ -956,255 +978,212 @@ impl<R: Read> Iterator for ByteCodeDecoder<R> {
             Ok(0x10) => self.format11x().ok().map(ByteCode::ReturnWide),
             Ok(0x11) => self.format11x().ok().map(ByteCode::ReturnObject),
             Ok(0x12) => {
-                self.format11n()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::Const4(reg, lit))
+                self.format11n().ok().map(
+                    |(reg, lit)| ByteCode::Const4(reg, lit),
+                )
             }
             Ok(0x13) => {
-                self.format21s()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::Const16(reg, lit))
+                self.format21s().ok().map(|(reg, lit)| {
+                    ByteCode::Const16(reg, lit)
+                })
             }
             Ok(0x14) => {
-                self.format31i()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::Const(reg, lit))
+                self.format31i().ok().map(
+                    |(reg, lit)| ByteCode::Const(reg, lit),
+                )
             }
             Ok(0x15) => {
-                self.format21hw()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::ConstHigh16(reg, lit))
+                self.format21hw().ok().map(|(reg, lit)| {
+                    ByteCode::ConstHigh16(reg, lit)
+                })
             }
             Ok(0x16) => {
-                self.format21s()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::ConstWide16(reg, lit as i64))
+                self.format21s().ok().map(|(reg, lit)| {
+                    ByteCode::ConstWide16(reg, lit as i64)
+                })
             }
             Ok(0x17) => {
-                self.format31i()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::ConstWide32(reg, lit as i64))
+                self.format31i().ok().map(|(reg, lit)| {
+                    ByteCode::ConstWide32(reg, lit as i64)
+                })
             }
             Ok(0x18) => {
-                self.format51l()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::ConstWide(reg, lit))
+                self.format51l().ok().map(|(reg, lit)| {
+                    ByteCode::ConstWide(reg, lit)
+                })
             }
             Ok(0x19) => {
-                self.format21hd()
-                    .ok()
-                    .map(|(reg, lit)| ByteCode::ConstWideHigh16(reg, lit))
+                self.format21hd().ok().map(|(reg, lit)| {
+                    ByteCode::ConstWideHigh16(reg, lit)
+                })
             }
             Ok(0x1A) => {
-                self.format21c()
-                    .ok()
-                    .map(|(reg, reference)| {
-                             ByteCode::ConstString(reg, reference as StringReference)
-                         })
+                self.format21c().ok().map(|(reg, reference)| {
+                    ByteCode::ConstString(reg, reference as StringReference)
+                })
             }
             Ok(0x1B) => {
-                self.format31c()
-                    .ok()
-                    .map(|(reg, reference)| {
-                             ByteCode::ConstStringJumbo(reg, reference as StringReference)
-                         })
+                self.format31c().ok().map(|(reg, reference)| {
+                    ByteCode::ConstStringJumbo(reg, reference as StringReference)
+                })
             }
             Ok(0x1C) => {
-                self.format21c()
-                    .ok()
-                    .map(|(reg, reference)| ByteCode::ConstClass(reg, reference as ClassReference))
+                self.format21c().ok().map(|(reg, reference)| {
+                    ByteCode::ConstClass(reg, reference as ClassReference)
+                })
             }
             Ok(0x1D) => self.format11x().ok().map(ByteCode::MonitorEnter),
             Ok(0x1E) => self.format11x().ok().map(ByteCode::MonitorExit),
             Ok(0x1F) => {
-                self.format21c()
-                    .ok()
-                    .map(|(reg, reference)| ByteCode::CheckCast(reg, reference as TypeReference))
+                self.format21c().ok().map(|(reg, reference)| {
+                    ByteCode::CheckCast(reg, reference as TypeReference)
+                })
             }
             Ok(0x20) => {
-                self.format22c()
-                    .ok()
-                    .map(|(dest, src, reference)| {
-                             ByteCode::InstanceOf(dest, src, reference as TypeReference)
-                         })
+                self.format22c().ok().map(|(dest, src, reference)| {
+                    ByteCode::InstanceOf(dest, src, reference as TypeReference)
+                })
             }
             Ok(0x21) => {
-                self.format12x()
-                    .ok()
-                    .map(|(dest, src)| ByteCode::ArrayLength(dest, src))
+                self.format12x().ok().map(|(dest, src)| {
+                    ByteCode::ArrayLength(dest, src)
+                })
             }
             Ok(0x22) => {
-                self.format21c()
-                    .ok()
-                    .map(|(dest, reference)| {
-                             ByteCode::NewInstance(dest, reference as TypeReference)
-                         })
+                self.format21c().ok().map(|(dest, reference)| {
+                    ByteCode::NewInstance(dest, reference as TypeReference)
+                })
             }
             Ok(0x23) => {
-                self.format22c()
-                    .ok()
-                    .map(|(dest, size, reference)| {
-                             ByteCode::NewArray(dest, size, reference as TypeReference)
-                         })
+                self.format22c().ok().map(|(dest, size, reference)| {
+                    ByteCode::NewArray(dest, size, reference as TypeReference)
+                })
             }
             Ok(0x24) => {
-                self.format35c()
-                    .ok()
-                    .map(|(registers, reference)| {
-                             ByteCode::FilledNewArray(registers, reference as TypeReference)
-                         })
+                self.format35c().ok().map(|(registers, reference)| {
+                    ByteCode::FilledNewArray(registers, reference as TypeReference)
+                })
             }
             Ok(0x25) => {
-                self.format3rc()
-                    .ok()
-                    .map(|(first, amount, reference)| {
-                             ByteCode::FilledNewArrayRange(first,
-                                                           amount,
-                                                           reference as TypeReference)
-                         })
+                self.format3rc().ok().map(|(first, amount, reference)| {
+                    ByteCode::FilledNewArrayRange(first, amount, reference as TypeReference)
+                })
             }
             Ok(0x26) => {
-                self.format31t()
-                    .ok()
-                    .map(|(reg, offset)| ByteCode::FillArrayData(reg, offset))
+                self.format31t().ok().map(|(reg, offset)| {
+                    ByteCode::FillArrayData(reg, offset)
+                })
             }
             Ok(0x27) => self.format11x().ok().map(ByteCode::Throw),
             Ok(0x28) => self.format10t().ok().map(ByteCode::Goto),
             Ok(0x29) => self.format20t().ok().map(ByteCode::Goto16),
             Ok(0x2A) => self.format30t().ok().map(ByteCode::Goto32),
             Ok(0x2B) => {
-                self.format31t()
-                    .ok()
-                    .map(|(reg, offset)| ByteCode::PackedSwitch(reg, offset))
+                self.format31t().ok().map(|(reg, offset)| {
+                    ByteCode::PackedSwitch(reg, offset)
+                })
             }
             Ok(0x2C) => {
-                self.format31t()
-                    .ok()
-                    .map(|(reg, offset)| ByteCode::SparseSwitch(reg, offset))
+                self.format31t().ok().map(|(reg, offset)| {
+                    ByteCode::SparseSwitch(reg, offset)
+                })
             }
             Ok(a @ 0x2D...0x31) => {
-                self.format23x()
-                    .ok()
-                    .map(|(dest, op1, op2)| ByteCode::Compare(CompareType::from(a), dest, op1, op2))
+                self.format23x().ok().map(|(dest, op1, op2)| {
+                    ByteCode::Compare(CompareType::from(a), dest, op1, op2)
+                })
             }
             Ok(a @ 0x32...0x37) => {
-                self.format22t()
-                    .ok()
-                    .map(|(dest, src, offset)| ByteCode::If(TestType::from(a), dest, src, offset))
+                self.format22t().ok().map(|(dest, src, offset)| {
+                    ByteCode::If(TestType::from(a), dest, src, offset)
+                })
             }
             Ok(a @ 0x38...0x3D) => {
-                self.format21t()
-                    .ok()
-                    .map(|(dest, offset)| ByteCode::If0(TestType::from(a), dest, offset))
+                self.format21t().ok().map(|(dest, offset)| {
+                    ByteCode::If0(TestType::from(a), dest, offset)
+                })
             }
             Ok(a @ 0x44...0x51) => {
-                self.format23x()
-                    .ok()
-                    .map(|(dest, op1, op2)| {
-                             ByteCode::Array(ArrayOperation::from(a), dest, op1, op2)
-                         })
+                self.format23x().ok().map(|(dest, op1, op2)| {
+                    ByteCode::Array(ArrayOperation::from(a), dest, op1, op2)
+                })
             }
             Ok(a @ 0x52...0x5f) => {
-                self.format22c()
-                    .ok()
-                    .map(|(dest, op1, reference)| {
-                             ByteCode::Instance(ArrayOperation::from(a),
-                                                dest,
-                                                op1,
-                                                reference as FieldReference)
-                         })
+                self.format22c().ok().map(|(dest, op1, reference)| {
+                    ByteCode::Instance(
+                        ArrayOperation::from(a),
+                        dest,
+                        op1,
+                        reference as FieldReference,
+                    )
+                })
             }
             Ok(a @ 0x60...0x6d) => {
-                self.format21c()
-                    .ok()
-                    .map(|(dest, reference)| {
-                             ByteCode::Static(ArrayOperation::from(a),
-                                              dest,
-                                              reference as FieldReference)
-                         })
+                self.format21c().ok().map(|(dest, reference)| {
+                    ByteCode::Static(ArrayOperation::from(a), dest, reference as FieldReference)
+                })
             }
             Ok(a @ 0x6e...0x72) => {
-                self.format35c()
-                    .ok()
-                    .map(|(registers, reference)| {
-                             ByteCode::Invoke(InvokeKind::from(a),
-                                              registers,
-                                              reference as MethodReference)
-                         })
+                self.format35c().ok().map(|(registers, reference)| {
+                    ByteCode::Invoke(InvokeKind::from(a), registers, reference as MethodReference)
+                })
             }
             Ok(a @ 0x74...0x78) => {
-                self.format3rc()
-                    .ok()
-                    .map(|(first, amount, reference)| {
-                             ByteCode::InvokeRange(InvokeKind::from(a),
-                                                   first,
-                                                   amount,
-                                                   reference as FieldReference)
-                         })
+                self.format3rc().ok().map(|(first, amount, reference)| {
+                    ByteCode::InvokeRange(
+                        InvokeKind::from(a),
+                        first,
+                        amount,
+                        reference as FieldReference,
+                    )
+                })
             }
             Ok(op @ 0x7b...0x8f) => {
-                self.format12x()
-                    .ok()
-                    .map(|(dest, src)| ByteCode::Unary(UnaryOperation::from(op), dest, src))
+                self.format12x().ok().map(|(dest, src)| {
+                    ByteCode::Unary(UnaryOperation::from(op), dest, src)
+                })
             }
             Ok(op @ 0x90...0xaf) => {
-                self.format23x()
-                    .ok()
-                    .map(|(dest, src1, src2)| {
-                             ByteCode::Binary(BinaryOperation::from(op), dest, src1, src2)
-                         })
+                self.format23x().ok().map(|(dest, src1, src2)| {
+                    ByteCode::Binary(BinaryOperation::from(op), dest, src1, src2)
+                })
             }
             Ok(op @ 0xb0...0xcf) => {
-                self.format12x()
-                    .ok()
-                    .map(|(srcdest, src)| {
-                             ByteCode::Binary2Addr(BinaryOperation::from(op), srcdest, src)
-                         })
+                self.format12x().ok().map(|(srcdest, src)| {
+                    ByteCode::Binary2Addr(BinaryOperation::from(op), srcdest, src)
+                })
             }
             Ok(op @ 0xd0...0xd7) => {
-                self.format22s()
-                    .ok()
-                    .map(|(dest, src, literal)| {
-                             ByteCode::BinaryLit16(BinaryOperation::from(op), dest, src, literal)
-                         })
+                self.format22s().ok().map(|(dest, src, literal)| {
+                    ByteCode::BinaryLit16(BinaryOperation::from(op), dest, src, literal)
+                })
             }
             Ok(op @ 0xd8...0xe2) => {
-                self.format22b()
-                    .ok()
-                    .map(|(dest, src, literal)| {
-                             ByteCode::BinaryLit8(BinaryOperation::from(op), dest, src, literal)
-                         })
+                self.format22b().ok().map(|(dest, src, literal)| {
+                    ByteCode::BinaryLit8(BinaryOperation::from(op), dest, src, literal)
+                })
             }
             Ok(0xfa) => {
-                self.format45cc()
-                    .ok()
-                    .map(|(registers, method, proto)| {
-                             ByteCode::InvokePolymorphic(registers, method as u32, proto as u32)
-                         })
+                self.format45cc().ok().map(|(registers, method, proto)| {
+                    ByteCode::InvokePolymorphic(registers, method as u32, proto as u32)
+                })
             }
             Ok(0xfb) => {
-                self.format4rcc()
-                    .ok()
-                    .map(|(first, amount, method, proto)| {
-                             ByteCode::InvokePolymorphicRange(first,
-                                                              amount,
-                                                              method as u32,
-                                                              proto as u32)
-                         })
+                self.format4rcc().ok().map(
+                    |(first, amount, method, proto)| {
+                        ByteCode::InvokePolymorphicRange(first, amount, method as u32, proto as u32)
+                    },
+                )
             }
             Ok(0xfc) => {
-                self.format35c()
-                    .ok()
-                    .map(|(registers, call_site)| {
-                             ByteCode::InvokeCustom(registers, call_site as u32)
-                         })
+                self.format35c().ok().map(|(registers, call_site)| {
+                    ByteCode::InvokeCustom(registers, call_site as u32)
+                })
             }
             Ok(0xfd) => {
-                self.format3rc()
-                    .ok()
-                    .map(|(first, amount, call_site)| {
-                             ByteCode::InvokeCustomRange(first, amount, call_site as u32)
-                         })
+                self.format3rc().ok().map(|(first, amount, call_site)| {
+                    ByteCode::InvokeCustomRange(first, amount, call_site as u32)
+                })
             }
             _ => None,
         }
@@ -1508,11 +1487,15 @@ mod tests {
 
         let opcode = d.nth(0).unwrap();
 
-        assert_eq!("const-wide/high16 v1, #-281474976710656",
-                   opcode.to_string());
-        assert!(matches!(
+        assert_eq!(
+            "const-wide/high16 v1, #-281474976710656",
+            opcode.to_string()
+        );
+        assert!(
+            matches!(
             opcode,
-            ByteCode::ConstWideHigh16(r, i) if r == 1 && i == -281474976710656));
+            ByteCode::ConstWideHigh16(r, i) if r == 1 && i == -281474976710656)
+        );
     }
 
     #[test]
@@ -1523,9 +1506,11 @@ mod tests {
         let opcode = d.nth(0).unwrap();
 
         assert_eq!("const-string v1, string@65535", opcode.to_string());
-        assert!(matches!(
+        assert!(
+            matches!(
             opcode,
-            ByteCode::ConstString(r, i) if r == 1 && i == 65535 as StringReference));
+            ByteCode::ConstString(r, i) if r == 1 && i == 65535 as StringReference)
+        );
     }
 
     #[test]
@@ -1535,11 +1520,15 @@ mod tests {
 
         let opcode = d.nth(0).unwrap();
 
-        assert_eq!("const-string/jumbo v1, string@268500991",
-                   opcode.to_string());
-        assert!(matches!(
+        assert_eq!(
+            "const-string/jumbo v1, string@268500991",
+            opcode.to_string()
+        );
+        assert!(
+            matches!(
             opcode,
-            ByteCode::ConstStringJumbo(r, i) if r == 1 && i == 268500991 as StringReference));
+            ByteCode::ConstStringJumbo(r, i) if r == 1 && i == 268500991 as StringReference)
+        );
     }
 
     #[test]
@@ -1550,9 +1539,11 @@ mod tests {
         let opcode = d.nth(0).unwrap();
 
         assert_eq!("const-class v1, class@4369", opcode.to_string());
-        assert!(matches!(
+        assert!(
+            matches!(
             opcode,
-            ByteCode::ConstClass(r, i) if r == 1 && i == 4369 as ClassReference));
+            ByteCode::ConstClass(r, i) if r == 1 && i == 4369 as ClassReference)
+        );
     }
 
     #[test]
@@ -1585,9 +1576,11 @@ mod tests {
         let opcode = d.nth(0).unwrap();
 
         assert_eq!("check-cast v1, type@4369", opcode.to_string());
-        assert!(matches!(
+        assert!(
+            matches!(
             opcode,
-            ByteCode::CheckCast(r, i) if r == 1 && i == 4369 as TypeReference));
+            ByteCode::CheckCast(r, i) if r == 1 && i == 4369 as TypeReference)
+        );
     }
 
     #[test]
@@ -1598,9 +1591,11 @@ mod tests {
         let opcode = d.nth(0).unwrap();
 
         assert_eq!("instance-of v2, v10, type@4369", opcode.to_string());
-        assert!(matches!(
+        assert!(
+            matches!(
             opcode,
-            ByteCode::InstanceOf(d, s, i) if d == 2 && s == 10 && i == 4369 as TypeReference));
+            ByteCode::InstanceOf(d, s, i) if d == 2 && s == 10 && i == 4369 as TypeReference)
+        );
     }
 
     #[test]
@@ -1635,9 +1630,11 @@ mod tests {
         let opcode = d.nth(0).unwrap();
 
         assert_eq!("new-array v9, v10, type@32", opcode.to_string());
-        assert!(matches!(
+        assert!(
+            matches!(
             opcode,
-            ByteCode::NewArray(d, s, reference) if d == 9 && s == 10 && reference == 32));
+            ByteCode::NewArray(d, s, reference) if d == 9 && s == 10 && reference == 32)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,12 @@ impl Dex {
 
     /// Loads a new Dex data structure from the given reader.
     pub fn from_reader<R: BufRead>(reader: R, size: Option<usize>) -> Result<Dex> {
-        let mut dex_reader = DexReader::new(reader, size)
-            .chain_err(|| "could not create reader")?;
-        dex_reader
-            .read_data()
-            .chain_err(|| "could not read dex file")?;
+        let mut dex_reader = DexReader::new(reader, size).chain_err(
+            || "could not create reader",
+        )?;
+        dex_reader.read_data().chain_err(
+            || "could not read dex file",
+        )?;
 
         Ok(dex_reader.into())
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -66,9 +66,9 @@ impl FromStr for Type {
                             type_str.push(t);
                             type_str.push_str(chars.as_str());
                             return Ok(Type::Array {
-                                          dimensions: dimensions,
-                                          array_type: Box::new(type_str.parse()?),
-                                      });
+                                dimensions: dimensions,
+                                array_type: Box::new(type_str.parse()?),
+                            });
                         }
                         None => return Err(ErrorKind::InvalidTypeDescriptor(s.to_owned()).into()),
                     }
@@ -197,9 +197,9 @@ impl FromStr for ShortyDescriptor {
             field_types.push(ShortyFieldType::from_char(c)?);
         }
         Ok(ShortyDescriptor {
-               return_type: return_type,
-               field_types: field_types.into_boxed_slice(),
-           })
+            return_type: return_type,
+            field_types: field_types.into_boxed_slice(),
+        })
     }
 }
 
@@ -213,10 +213,11 @@ pub struct Prototype {
 
 impl Prototype {
     /// Creates a new prototype.
-    pub fn new<TA: Into<Option<Box<[Type]>>>>(descriptor: ShortyDescriptor,
-                                              return_type: Type,
-                                              parameters: TA)
-                                              -> Prototype {
+    pub fn new<TA: Into<Option<Box<[Type]>>>>(
+        descriptor: ShortyDescriptor,
+        return_type: Type,
+        parameters: TA,
+    ) -> Prototype {
         Prototype {
             descriptor,
             return_type,
@@ -353,11 +354,12 @@ pub struct AnnotationsDirectory {
 
 impl AnnotationsDirectory {
     /// Creates a new annotations directory.
-    pub fn new<CA: Into<Box<[Annotation]>>>(class_annotations: CA,
-                                            field_annotations: Box<[FieldAnnotations]>,
-                                            method_annotations: Box<[MethodAnnotations]>,
-                                            parameter_annotations: Box<[ParameterAnnotations]>)
-                                            -> AnnotationsDirectory {
+    pub fn new<CA: Into<Box<[Annotation]>>>(
+        class_annotations: CA,
+        field_annotations: Box<[FieldAnnotations]>,
+        method_annotations: Box<[MethodAnnotations]>,
+        parameter_annotations: Box<[ParameterAnnotations]>,
+    ) -> AnnotationsDirectory {
         AnnotationsDirectory {
             class_annotations: class_annotations.into(),
             field_annotations,
@@ -527,15 +529,16 @@ pub struct Class {
 
 impl Class {
     /// Creates a new class.
-    pub fn new(class_index: u32,
-               access_flags: AccessFlags,
-               superclass_index: Option<u32>,
-               interfaces: Box<[Type]>,
-               source_file_index: Option<u32>,
-               annotations: Option<AnnotationsDirectory>,
-               class_data: Option<ClassData>,
-               static_values: Option<Array>)
-               -> Class {
+    pub fn new(
+        class_index: u32,
+        access_flags: AccessFlags,
+        superclass_index: Option<u32>,
+        interfaces: Box<[Type]>,
+        source_file_index: Option<u32>,
+        annotations: Option<AnnotationsDirectory>,
+        class_data: Option<ClassData>,
+        static_values: Option<Array>,
+    ) -> Class {
         Class {
             class_index,
             access_flags,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,8 @@ pub mod read;
 
 use std::str::FromStr;
 use std::ops::Deref;
+use std::fmt::{Display, Formatter};
+use std::fmt;
 
 use error::*;
 use self::read::ClassData;
@@ -514,6 +516,93 @@ bitflags! {
     }
 }
 
+impl Display for AccessFlags {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut out = String::new();
+
+        if self.contains(ACC_PUBLIC) {
+            out.push_str("public ");
+        }
+
+        if self.contains(ACC_PRIVATE) {
+            out.push_str("private ");
+        }
+
+        if self.contains(ACC_PROTECTED) {
+            out.push_str("protected ");
+        }
+
+        if self.contains(ACC_STATIC) {
+            out.push_str("static ");
+        }
+
+        if self.contains(ACC_FINAL) {
+            out.push_str("final ");
+        }
+
+        if self.contains(ACC_SYNCHRONIZED) {
+            out.push_str("synchronized ");
+        }
+
+        if self.contains(ACC_VOLATILE) {
+            out.push_str("volatile ");
+        }
+
+        if self.contains(ACC_BRIDGE) {
+            out.push_str("bridge ");
+        }
+
+        if self.contains(ACC_TRANSIENT) {
+            out.push_str("transient ");
+        }
+
+        if self.contains(ACC_VARARGS) {
+            out.push_str("varargs ");
+        }
+
+        if self.contains(ACC_NATIVE) {
+            out.push_str("native ");
+        }
+
+        if self.contains(ACC_INTERFACE) {
+            out.push_str("interface ");
+        }
+
+        if self.contains(ACC_ABSTRACT) {
+            out.push_str("abstract ");
+        }
+
+        if self.contains(ACC_STRICT) {
+            out.push_str("strict ");
+        }
+
+        if self.contains(ACC_SYNTHETIC) {
+            out.push_str("synthetic ");
+        }
+
+        if self.contains(ACC_ANNOTATION) {
+            out.push_str("annotation ");
+        }
+
+        if self.contains(ACC_ENUM) {
+            out.push_str("enum ");
+        }
+
+        if self.contains(ACC_CONSTRUCTOR) {
+            out.push_str("constructor ");
+        }
+
+        if self.contains(ACC_DECLARED_SYNCHRONIZED) {
+            out.push_str("synchronized ");
+        }
+
+
+        write!(f, "{}", out.trim());
+
+        Ok(())
+    }
+}
+
 /// Structure representing a class.
 #[derive(Debug)]
 pub struct Class {
@@ -596,4 +685,27 @@ impl Class {
 
 
     // static_values: static_values,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_can_display_mixed_access_bitflags() {
+        let access = ACC_PUBLIC | ACC_DECLARED_SYNCHRONIZED;
+
+        let display = format!("{}", access);
+
+        assert_eq!("public synchronized", display);
+    }
+
+    #[test]
+    fn it_can_display_mixed_access_bitflags_protected_static_abstract() {
+        let access = ACC_PROTECTED | ACC_ABSTRACT | ACC_STATIC;
+
+        let display = format!("{}", access);
+
+        assert_eq!("protected static abstract", display);
+    }
 }

--- a/src/types/read.rs
+++ b/src/types/read.rs
@@ -20,24 +20,24 @@ pub struct PrototypeIdData {
 impl PrototypeIdData {
     /// Creates a new `PrototypeIdData` from a reader.
     pub fn from_reader<R: Read + Seek, B: ByteOrder>(reader: &mut R) -> Result<PrototypeIdData> {
-        let shorty_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the sorty_index field")?;
-        let return_type_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the return_type_index field")?;
-        let parameters_offset = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the parameters_offset field")?;
+        let shorty_index = reader.read_u32::<B>().chain_err(
+            || "could not read the sorty_index field",
+        )?;
+        let return_type_index = reader.read_u32::<B>().chain_err(
+            || "could not read the return_type_index field",
+        )?;
+        let parameters_offset = reader.read_u32::<B>().chain_err(
+            || "could not read the parameters_offset field",
+        )?;
         Ok(PrototypeIdData {
-               shorty_index: shorty_index,
-               return_type_index: return_type_index,
-               parameters_offset: if parameters_offset == 0 {
-                   None
-               } else {
-                   Some(parameters_offset)
-               },
-           })
+            shorty_index: shorty_index,
+            return_type_index: return_type_index,
+            parameters_offset: if parameters_offset == 0 {
+                None
+            } else {
+                Some(parameters_offset)
+            },
+        })
     }
 
     /// Gets the shorty index.
@@ -78,20 +78,20 @@ pub struct FieldIdData {
 impl FieldIdData {
     /// Creates a new `FieldIdData` from a reader.
     pub fn from_reader<R: Read, B: ByteOrder>(reader: &mut R) -> Result<FieldIdData> {
-        let class_index = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read the class_index field")?;
-        let type_index = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read the type_index field")?;
-        let name_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the name_index field")?;
+        let class_index = reader.read_u16::<B>().chain_err(
+            || "could not read the class_index field",
+        )?;
+        let type_index = reader.read_u16::<B>().chain_err(
+            || "could not read the type_index field",
+        )?;
+        let name_index = reader.read_u32::<B>().chain_err(
+            || "could not read the name_index field",
+        )?;
         Ok(FieldIdData {
-               class_index: class_index,
-               type_index: type_index,
-               name_index: name_index,
-           })
+            class_index: class_index,
+            type_index: type_index,
+            name_index: name_index,
+        })
     }
 
     /// Gets the index of the class of the field.
@@ -129,20 +129,20 @@ pub struct MethodIdData {
 impl MethodIdData {
     /// Creates a new `MethodIdData` from a reader.
     pub fn from_reader<R: Read, B: ByteOrder>(reader: &mut R) -> Result<MethodIdData> {
-        let class_index = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read the class_index field")?;
-        let prototype_index = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read the prototype_index field")?;
-        let name_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the name_index field")?;
+        let class_index = reader.read_u16::<B>().chain_err(
+            || "could not read the class_index field",
+        )?;
+        let prototype_index = reader.read_u16::<B>().chain_err(
+            || "could not read the prototype_index field",
+        )?;
+        let name_index = reader.read_u32::<B>().chain_err(
+            || "could not read the name_index field",
+        )?;
         Ok(MethodIdData {
-               class_index: class_index,
-               prototype_index: prototype_index,
-               name_index: name_index,
-           })
+            class_index: class_index,
+            prototype_index: prototype_index,
+            name_index: name_index,
+        })
     }
 
     /// Gets the index of the class of the field.
@@ -192,44 +192,43 @@ impl ClassDefData {
             if condition { Some(value) } else { None }
         }
 
-        let class_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the class_index field")?;
-        let access_flags = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the access_flags field")?;
-        let superclass_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the superclass_id field")?;
-        let interfaces_offset = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the interfaces_offset field")?;
-        let source_file_index = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the source_file_id field")?;
-        let annotations_offset = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the annotations_offset field")?;
-        let class_data_offset = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the class_data_offset field")?;
-        let static_values_offset =
-            reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read the static_values_offset field")?;
+        let class_index = reader.read_u32::<B>().chain_err(
+            || "could not read the class_index field",
+        )?;
+        let access_flags = reader.read_u32::<B>().chain_err(
+            || "could not read the access_flags field",
+        )?;
+        let superclass_index = reader.read_u32::<B>().chain_err(
+            || "could not read the superclass_id field",
+        )?;
+        let interfaces_offset = reader.read_u32::<B>().chain_err(
+            || "could not read the interfaces_offset field",
+        )?;
+        let source_file_index = reader.read_u32::<B>().chain_err(
+            || "could not read the source_file_id field",
+        )?;
+        let annotations_offset = reader.read_u32::<B>().chain_err(
+            || "could not read the annotations_offset field",
+        )?;
+        let class_data_offset = reader.read_u32::<B>().chain_err(
+            || "could not read the class_data_offset field",
+        )?;
+        let static_values_offset = reader.read_u32::<B>().chain_err(
+            || "could not read the static_values_offset field",
+        )?;
 
         Ok(ClassDefData {
-               class_index: class_index,
-               access_flags:
-                   AccessFlags::from_bits(access_flags)
-                       .ok_or_else(|| Error::from(ErrorKind::InvalidAccessFlags(access_flags)))?,
-               superclass_index: some_if(superclass_index, superclass_index != NO_INDEX),
-               interfaces_offset: some_if(interfaces_offset, interfaces_offset != 0),
-               source_file_index: some_if(source_file_index, source_file_index != NO_INDEX),
-               annotations_offset: some_if(annotations_offset, annotations_offset != 0),
-               class_data_offset: some_if(class_data_offset, class_data_offset != 0),
-               static_values_offset: some_if(static_values_offset, static_values_offset != 0),
-           })
+            class_index: class_index,
+            access_flags: AccessFlags::from_bits(access_flags).ok_or_else(|| {
+                Error::from(ErrorKind::InvalidAccessFlags(access_flags))
+            })?,
+            superclass_index: some_if(superclass_index, superclass_index != NO_INDEX),
+            interfaces_offset: some_if(interfaces_offset, interfaces_offset != 0),
+            source_file_index: some_if(source_file_index, source_file_index != NO_INDEX),
+            annotations_offset: some_if(annotations_offset, annotations_offset != 0),
+            class_data_offset: some_if(class_data_offset, class_data_offset != 0),
+            static_values_offset: some_if(static_values_offset, static_values_offset != 0),
+        })
     }
 
     /// Gets the index in the *Type IDs* list of the class.
@@ -314,84 +313,100 @@ const VALUE_BOOLEAN: u8 = 0x1f;
 impl Value {
     fn from_reader<R: Read>(reader: &mut R) -> Result<Value> {
         let mut value_type = [0_u8];
-        reader
-            .read_exact(&mut value_type)
-            .chain_err(|| "could not read the value_type field")?;
+        reader.read_exact(&mut value_type).chain_err(
+            || "could not read the value_type field",
+        )?;
         let arg = value_type[0] >> 5;
         let value_type = value_type[0] & 0b00011111;
 
         match value_type {
             VALUE_BYTE => {
                 if arg == 0 {
-                    Ok(Value::Byte(reader.read_i8().chain_err(|| "could not read Byte")?))
+                    Ok(Value::Byte(
+                        reader.read_i8().chain_err(|| "could not read Byte")?,
+                    ))
                 } else {
-                    Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Byte value", arg))
-                            .into())
+                    Err(
+                        ErrorKind::InvalidValue(format!("invalid arg ({}) for Byte value", arg))
+                            .into(),
+                    )
                 }
             }
             VALUE_SHORT => {
                 match arg {
                     0 => {
-                        Ok(Value::Short(reader.read_i8().chain_err(|| "could not read Short")? as
-                                        i16))
+                        Ok(Value::Short(
+                            reader.read_i8().chain_err(|| "could not read Short")? as
+                                i16,
+                        ))
                     }
                     1 => {
-                        Ok(Value::Short(reader
-                                            .read_i16::<LittleEndian>()
-                                            .chain_err(|| "could not read Short")?))
+                        Ok(Value::Short(reader.read_i16::<LittleEndian>().chain_err(
+                            || "could not read Short",
+                        )?))
                     }
                     a => {
-                        Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Short value", a))
-                                .into())
+                        Err(
+                            ErrorKind::InvalidValue(format!("invalid arg ({}) for Short value", a))
+                                .into(),
+                        )
                     }
                 }
             }
             VALUE_CHAR => {
                 match arg {
                     0 => {
-                        Ok(Value::Char(reader.read_u8().chain_err(|| "could not read Char")? as
-                                       u16))
+                        Ok(Value::Char(
+                            reader.read_u8().chain_err(|| "could not read Char")? as u16,
+                        ))
                     }
                     1 => {
-                        Ok(Value::Char(reader
-                                           .read_u16::<LittleEndian>()
-                                           .chain_err(|| "could not read Char")?))
+                        Ok(Value::Char(reader.read_u16::<LittleEndian>().chain_err(
+                            || "could not read Char",
+                        )?))
                     }
                     a => {
-                        Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Char value", a))
-                                .into())
+                        Err(
+                            ErrorKind::InvalidValue(format!("invalid arg ({}) for Char value", a))
+                                .into(),
+                        )
                     }
                 }
             }
             VALUE_INT => {
                 match arg {
                     0 => {
-                        Ok(Value::Int(reader.read_i8().chain_err(|| "could not read Int")? as i32))
+                        Ok(Value::Int(
+                            reader.read_i8().chain_err(|| "could not read Int")? as i32,
+                        ))
                     }
                     1 => {
-                        Ok(Value::Int(reader
-                                          .read_i16::<LittleEndian>()
-                                          .chain_err(|| "could not read Int")? as
-                                      i32))
+                        Ok(Value::Int(reader.read_i16::<LittleEndian>().chain_err(
+                            || "could not read Int",
+                        )? as i32))
                     }
                     2 => {
                         let mut bytes = [0_u8; 3];
-                        reader
-                            .read_exact(&mut bytes)
-                            .chain_err(|| "could not read Int")?;
+                        reader.read_exact(&mut bytes).chain_err(
+                            || "could not read Int",
+                        )?;
                         // Reading in little endian
-                        Ok(Value::Int(bytes[0] as i32 | (bytes[1] as i32) << 8 |
-                                      (bytes[2] as i8 as i32) << 16))
+                        Ok(Value::Int(
+                            bytes[0] as i32 | (bytes[1] as i32) << 8 |
+                                (bytes[2] as i8 as i32) << 16,
+                        ))
 
                     }
                     3 => {
-                        Ok(Value::Int(reader
-                                          .read_i32::<LittleEndian>()
-                                          .chain_err(|| "could not read Int")?))
+                        Ok(Value::Int(reader.read_i32::<LittleEndian>().chain_err(
+                            || "could not read Int",
+                        )?))
                     }
                     a => {
-                        Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Int value", a))
-                                .into())
+                        Err(
+                            ErrorKind::InvalidValue(format!("invalid arg ({}) for Int value", a))
+                                .into(),
+                        )
                     }
                 }
             }
@@ -399,70 +414,73 @@ impl Value {
                 match arg {
                     0 => Ok(Value::Long(reader.read_i8()? as i64)),
                     1 => {
-                        Ok(Value::Long(reader
-                                           .read_i16::<LittleEndian>()
-                                           .chain_err(|| "could not read Long")? as
-                                       i64))
+                        Ok(Value::Long(reader.read_i16::<LittleEndian>().chain_err(
+                            || "could not read Long",
+                        )? as i64))
                     }
                     2 => {
                         let mut bytes = [0_u8; 3];
-                        reader
-                            .read_exact(&mut bytes)
-                            .chain_err(|| "could not read Long")?;
+                        reader.read_exact(&mut bytes).chain_err(
+                            || "could not read Long",
+                        )?;
                         // Reading in little endian
-                        Ok(Value::Long(bytes[0] as i64 | (bytes[1] as i64) << 8 |
-                                       (bytes[2] as i8 as i64) << 16))
+                        Ok(Value::Long(
+                            bytes[0] as i64 | (bytes[1] as i64) << 8 |
+                                (bytes[2] as i8 as i64) << 16,
+                        ))
 
                     }
                     3 => {
-                        Ok(Value::Long(reader
-                                           .read_i32::<LittleEndian>()
-                                           .chain_err(|| "could not read Long")? as
-                                       i64))
+                        Ok(Value::Long(reader.read_i32::<LittleEndian>().chain_err(
+                            || "could not read Long",
+                        )? as i64))
                     }
                     4 => {
                         let mut bytes = [0_u8; 5];
-                        reader
-                            .read_exact(&mut bytes)
-                            .chain_err(|| "could not read Long")?;
+                        reader.read_exact(&mut bytes).chain_err(
+                            || "could not read Long",
+                        )?;
                         // Reading in little endian
-                        Ok(Value::Long(bytes[0] as i64 | (bytes[1] as i64) << 8 |
-                                       (bytes[2] as i64) << 16 |
-                                       (bytes[3] as i64) << 24 |
-                                       (bytes[4] as i8 as i64) << 32))
+                        Ok(Value::Long(
+                            bytes[0] as i64 | (bytes[1] as i64) << 8 | (bytes[2] as i64) << 16 |
+                                (bytes[3] as i64) << 24 |
+                                (bytes[4] as i8 as i64) << 32,
+                        ))
 
                     }
                     5 => {
                         let mut bytes = [0_u8; 6];
-                        reader
-                            .read_exact(&mut bytes)
-                            .chain_err(|| "could not read Long")?;
+                        reader.read_exact(&mut bytes).chain_err(
+                            || "could not read Long",
+                        )?;
                         // Reading in little endian
-                        Ok(Value::Long(bytes[0] as i64 | (bytes[1] as i64) << 8 |
-                                       (bytes[2] as i64) << 16 |
-                                       (bytes[3] as i64) << 24 |
-                                       (bytes[4] as i64) << 32 |
-                                       (bytes[5] as i8 as i64) << 40))
+                        Ok(Value::Long(
+                            bytes[0] as i64 | (bytes[1] as i64) << 8 | (bytes[2] as i64) << 16 |
+                                (bytes[3] as i64) << 24 |
+                                (bytes[4] as i64) << 32 |
+                                (bytes[5] as i8 as i64) << 40,
+                        ))
 
                     }
                     6 => {
                         let mut bytes = [0_u8; 7];
-                        reader
-                            .read_exact(&mut bytes)
-                            .chain_err(|| "could not read Long")?;
+                        reader.read_exact(&mut bytes).chain_err(
+                            || "could not read Long",
+                        )?;
                         // Reading in little endian
-                        Ok(Value::Long(bytes[0] as i64 | (bytes[1] as i64) << 8 |
-                                       (bytes[2] as i64) << 16 |
-                                       (bytes[3] as i64) << 24 |
-                                       (bytes[4] as i64) << 32 |
-                                       (bytes[5] as i64) << 40 |
-                                       (bytes[6] as i8 as i64) << 48))
+                        Ok(Value::Long(
+                            bytes[0] as i64 | (bytes[1] as i64) << 8 | (bytes[2] as i64) << 16 |
+                                (bytes[3] as i64) << 24 |
+                                (bytes[4] as i64) << 32 |
+                                (bytes[5] as i64) << 40 |
+                                (bytes[6] as i8 as i64) << 48,
+                        ))
 
                     }
                     7 => {
-                        Ok(Value::Long(reader
-                                           .read_i64::<LittleEndian>()
-                                           .chain_err(|| "could not read Long")?))
+                        Ok(Value::Long(reader.read_i64::<LittleEndian>().chain_err(
+                            || "could not read Long",
+                        )?))
                     }
                     _ => unreachable!(),
                 }
@@ -471,14 +489,16 @@ impl Value {
                 match arg {
                     c @ 0...3 => {
                         let mut bytes = [0_u8; 4];
-                        reader
-                            .read_exact(&mut bytes[..c as usize + 1])
-                            .chain_err(|| "could not read Float")?;
+                        reader.read_exact(&mut bytes[..c as usize + 1]).chain_err(
+                            || "could not read Float",
+                        )?;
                         Ok(Value::Float(LittleEndian::read_f32(&bytes)))
                     }
                     a => {
-                        Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Float value", a))
-                                .into())
+                        Err(
+                            ErrorKind::InvalidValue(format!("invalid arg ({}) for Float value", a))
+                                .into(),
+                        )
                     }
                 }
             }
@@ -486,9 +506,9 @@ impl Value {
                 match arg {
                     c @ 0...7 => {
                         let mut bytes = [0_u8; 8];
-                        reader
-                            .read_exact(&mut bytes[..c as usize + 1])
-                            .chain_err(|| "could not read Double")?;
+                        reader.read_exact(&mut bytes[..c as usize + 1]).chain_err(
+                            || "could not read Double",
+                        )?;
                         Ok(Value::Double(LittleEndian::read_f64(&bytes)))
                     }
                     _ => unreachable!(),
@@ -497,38 +517,45 @@ impl Value {
             VALUE_METHOD_TYPE => unimplemented!(),
             VALUE_METHOD_HANDLE => unimplemented!(),
             VALUE_STRING => {
-                let string_index = Value::read_u32(reader, arg)
-                    .chain_err(|| "could not read String index")?;
+                let string_index = Value::read_u32(reader, arg).chain_err(
+                    || "could not read String index",
+                )?;
                 Ok(Value::String(string_index))
             }
             VALUE_TYPE => {
-                let type_index = Value::read_u32(reader, arg)
-                    .chain_err(|| "could not read Type index")?;
+                let type_index = Value::read_u32(reader, arg).chain_err(
+                    || "could not read Type index",
+                )?;
                 Ok(Value::Type(type_index))
             }
             VALUE_FIELD => {
-                let field_index = Value::read_u32(reader, arg)
-                    .chain_err(|| "could not read Field index")?;
+                let field_index = Value::read_u32(reader, arg).chain_err(
+                    || "could not read Field index",
+                )?;
                 Ok(Value::Field(field_index))
             }
             VALUE_METHOD => {
-                let method_index = Value::read_u32(reader, arg)
-                    .chain_err(|| "could not read Method index")?;
+                let method_index = Value::read_u32(reader, arg).chain_err(
+                    || "could not read Method index",
+                )?;
                 Ok(Value::Method(method_index))
             }
             VALUE_ENUM => {
-                let enum_index = Value::read_u32(reader, arg)
-                    .chain_err(|| "could not read Enum index")?;
+                let enum_index = Value::read_u32(reader, arg).chain_err(
+                    || "could not read Enum index",
+                )?;
                 Ok(Value::Enum(enum_index))
             }
             VALUE_ARRAY => {
-                let array = Array::from_reader(reader)
-                    .chain_err(|| "could not read Array")?;
+                let array = Array::from_reader(reader).chain_err(
+                    || "could not read Array",
+                )?;
                 Ok(Value::Array(array))
             }
             VALUE_ANNOTATION => {
-                let annotation = EncodedAnnotation::from_reader(reader)
-                    .chain_err(|| "could not read Annotation value")?;
+                let annotation = EncodedAnnotation::from_reader(reader).chain_err(
+                    || "could not read Annotation value",
+                )?;
                 Ok(Value::Annotation(annotation))
             }
             VALUE_NULL => Ok(Value::Null),
@@ -537,13 +564,17 @@ impl Value {
                     0 => Ok(Value::Boolean(false)),
                     1 => Ok(Value::Boolean(true)),
                     _ => {
-                        Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for Boolean value",
-                                                            arg))
-                                    .into())
+                        Err(
+                            ErrorKind::InvalidValue(
+                                format!("invalid arg ({}) for Boolean value", arg),
+                            ).into(),
+                        )
                     }
                 }
             }
-            v => Err(ErrorKind::InvalidValue(format!("invalid value type {:#04x}", v)).into()),
+            v => Err(
+                ErrorKind::InvalidValue(format!("invalid value type {:#04x}", v)).into(),
+            ),
         }
     }
 
@@ -555,11 +586,15 @@ impl Value {
                 let mut bytes = [0_u8; 3];
                 reader.read_exact(&mut bytes)?;
                 // Reading in little endian
-                Ok(bytes[0] as u32 | (bytes[1] as u32) << 8 | (bytes[2] as u32) << 16)
+                Ok(
+                    bytes[0] as u32 | (bytes[1] as u32) << 8 | (bytes[2] as u32) << 16,
+                )
 
             }
             3 => Ok(reader.read_u32::<LittleEndian>()?),
-            a => Err(ErrorKind::InvalidValue(format!("invalid arg ({}) for u32 value", a)).into()),
+            a => Err(
+                ErrorKind::InvalidValue(format!("invalid arg ({}) for u32 value", a)).into(),
+            ),
         }
     }
 }
@@ -567,12 +602,14 @@ impl Value {
 impl Array {
     /// Creates an array from a reader.
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<Array> {
-        let (size, _) = read_uleb128(reader)
-            .chain_err(|| "could not read array size")?;
+        let (size, _) = read_uleb128(reader).chain_err(
+            || "could not read array size",
+        )?;
         let mut array = Vec::with_capacity(size as usize);
         for _ in 0..size {
-            let value = Value::from_reader(reader)
-                .chain_err(|| "could not read value")?;
+            let value = Value::from_reader(reader).chain_err(
+                || "could not read value",
+            )?;
             array.push(value);
         }
         Ok(Array { inner: array.into_boxed_slice() })
@@ -587,19 +624,21 @@ impl EncodedAnnotation {
         let (size, _) = read_uleb128(reader).chain_err(|| "could not read size")?;
         let mut elements = Vec::with_capacity(size as usize);
         for _ in 0..size {
-            let (name_id, _) = read_uleb128(reader)
-                .chain_err(|| "could not read element's name_id")?;
-            let value = Value::from_reader(reader)
-                .chain_err(|| "could not read element's value")?;
+            let (name_id, _) = read_uleb128(reader).chain_err(
+                || "could not read element's name_id",
+            )?;
+            let value = Value::from_reader(reader).chain_err(
+                || "could not read element's value",
+            )?;
             elements.push(AnnotationElement {
-                              name: name_id,
-                              value: value,
-                          });
+                name: name_id,
+                value: value,
+            });
         }
         Ok(EncodedAnnotation {
-               type_id: type_id,
-               elements: elements.into_boxed_slice(),
-           })
+            type_id: type_id,
+            elements: elements.into_boxed_slice(),
+        })
     }
 }
 
@@ -608,16 +647,19 @@ impl Annotation {
     #[doc(hidden)]
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<Annotation> {
         let mut visibility = [0_u8];
-        reader
-            .read_exact(&mut visibility)
-            .chain_err(|| "could not read visibility")?;
+        reader.read_exact(&mut visibility).chain_err(
+            || "could not read visibility",
+        )?;
         let visibility = Visibility::from_u8(visibility[0])?;
-        let annotation = EncodedAnnotation::from_reader(reader)
-            .chain_err(|| "could not read annotation")?;
-        Ok((Annotation {
-                visibility: visibility,
-                annotation: annotation,
-            }))
+        let annotation = EncodedAnnotation::from_reader(reader).chain_err(
+            || "could not read annotation",
+        )?;
+        Ok(
+            (Annotation {
+                 visibility: visibility,
+                 annotation: annotation,
+             }),
+        )
     }
 }
 
@@ -689,74 +731,71 @@ pub struct AnnotationsDirectoryOffsets {
 
 impl AnnotationsDirectoryOffsets {
     /// Creates a new annotations directory from a reader.
-    pub fn from_reader<R: Read, B: ByteOrder>(reader: &mut R)
-                                              -> Result<AnnotationsDirectoryOffsets> {
-        let class_annotations_offset =
-            reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read class annotations offset")?;
-        let field_annotations_size = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read field annotations size")? as
-                                     usize;
-        let method_annotations_size =
-            reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read method annotations size")? as usize;
-        let parameter_annotations_size =
-            reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read parameter annotations size")? as usize;
+    pub fn from_reader<R: Read, B: ByteOrder>(
+        reader: &mut R,
+    ) -> Result<AnnotationsDirectoryOffsets> {
+        let class_annotations_offset = reader.read_u32::<B>().chain_err(
+            || "could not read class annotations offset",
+        )?;
+        let field_annotations_size = reader.read_u32::<B>().chain_err(
+            || "could not read field annotations size",
+        )? as usize;
+        let method_annotations_size = reader.read_u32::<B>().chain_err(
+            || "could not read method annotations size",
+        )? as usize;
+        let parameter_annotations_size = reader.read_u32::<B>().chain_err(
+            || "could not read parameter annotations size",
+        )? as usize;
 
         let mut field_annotations = Vec::with_capacity(field_annotations_size);
         for _ in 0..field_annotations_size {
-            let field_id = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read field ID for field annotation")?;
-            let offset = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read field annotation offset")?;
+            let field_id = reader.read_u32::<B>().chain_err(
+                || "could not read field ID for field annotation",
+            )?;
+            let offset = reader.read_u32::<B>().chain_err(
+                || "could not read field annotation offset",
+            )?;
             field_annotations.push(FieldAnnotationsOffset {
-                                       field_id: field_id,
-                                       offset: offset,
-                                   });
+                field_id: field_id,
+                offset: offset,
+            });
         }
         let mut method_annotations = Vec::with_capacity(method_annotations_size);
         for _ in 0..method_annotations_size {
-            let method_id = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read method ID for method annotation")?;
-            let offset = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read method annotation offset")?;
+            let method_id = reader.read_u32::<B>().chain_err(
+                || "could not read method ID for method annotation",
+            )?;
+            let offset = reader.read_u32::<B>().chain_err(
+                || "could not read method annotation offset",
+            )?;
             method_annotations.push(MethodAnnotationsOffset {
-                                        method_id: method_id,
-                                        offset: offset,
-                                    });
+                method_id: method_id,
+                offset: offset,
+            });
         }
         let mut parameter_annotations = Vec::with_capacity(parameter_annotations_size);
         for _ in 0..parameter_annotations_size {
-            let method_id = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read method ID for parameter annotation")?;
-            let offset = reader
-                .read_u32::<B>()
-                .chain_err(|| "could not read annotation offset")?;
+            let method_id = reader.read_u32::<B>().chain_err(
+                || "could not read method ID for parameter annotation",
+            )?;
+            let offset = reader.read_u32::<B>().chain_err(
+                || "could not read annotation offset",
+            )?;
             parameter_annotations.push(ParameterAnnotationsOffset {
-                                           method_id: method_id,
-                                           offset: offset,
-                                       });
+                method_id: method_id,
+                offset: offset,
+            });
         }
         Ok(AnnotationsDirectoryOffsets {
-               class_annotations_offset: if class_annotations_offset == 0 {
-                   None
-               } else {
-                   Some(class_annotations_offset)
-               },
-               field_annotations: field_annotations.into_boxed_slice(),
-               method_annotations: method_annotations.into_boxed_slice(),
-               parameter_annotations: parameter_annotations.into_boxed_slice(),
-           })
+            class_annotations_offset: if class_annotations_offset == 0 {
+                None
+            } else {
+                Some(class_annotations_offset)
+            },
+            field_annotations: field_annotations.into_boxed_slice(),
+            method_annotations: method_annotations.into_boxed_slice(),
+            parameter_annotations: parameter_annotations.into_boxed_slice(),
+        })
     }
 
     /// Gets the class annotations offset, if they exist.
@@ -805,17 +844,18 @@ pub struct ClassData {
 impl ClassData {
     /// Creates a new class data structure from a reader.
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<ClassData> {
-        let (static_fields_size, _) = read_uleb128(reader)
-            .chain_err(|| "could not read static_fields_size field")?;
-        let (instance_fields_size, _) =
-            read_uleb128(reader)
-                .chain_err(|| "could not read instance_fields_size field")?;
-        let (direct_methods_size, _) =
-            read_uleb128(reader)
-                .chain_err(|| "could not read direct_methods_size field")?;
-        let (virtual_methods_size, _) =
-            read_uleb128(reader)
-                .chain_err(|| "could not read virtual_methods_size field")?;
+        let (static_fields_size, _) = read_uleb128(reader).chain_err(
+            || "could not read static_fields_size field",
+        )?;
+        let (instance_fields_size, _) = read_uleb128(reader).chain_err(
+            || "could not read instance_fields_size field",
+        )?;
+        let (direct_methods_size, _) = read_uleb128(reader).chain_err(
+            || "could not read direct_methods_size field",
+        )?;
+        let (virtual_methods_size, _) = read_uleb128(reader).chain_err(
+            || "could not read virtual_methods_size field",
+        )?;
 
         let mut static_fields = Vec::with_capacity(static_fields_size as usize);
         ClassData::read_fields(reader, static_fields_size, &mut static_fields)
@@ -834,66 +874,70 @@ impl ClassData {
             .chain_err(|| "could not read class virtual methods")?;
 
         Ok(ClassData {
-               static_fields: static_fields,
-               instance_fields: instance_fields,
-               direct_methods: direct_methods,
-               virtual_methods: virtual_methods,
-           })
+            static_fields: static_fields,
+            instance_fields: instance_fields,
+            direct_methods: direct_methods,
+            virtual_methods: virtual_methods,
+        })
     }
 
-    fn read_fields<R: Read>(reader: &mut R,
-                            field_count: u32,
-                            field_vec: &mut Vec<Field>)
-                            -> Result<()> {
+    fn read_fields<R: Read>(
+        reader: &mut R,
+        field_count: u32,
+        field_vec: &mut Vec<Field>,
+    ) -> Result<()> {
         if field_count > 0 {
             // First field's ID is given directly.
-            let (field_id, _) = read_uleb128(reader)
-                .chain_err(|| "could not read field ID")?;
-            let (access_flags, _) = read_uleb128(reader)
-                .chain_err(|| "could not read field access flags")?;
+            let (field_id, _) = read_uleb128(reader).chain_err(|| "could not read field ID")?;
+            let (access_flags, _) = read_uleb128(reader).chain_err(
+                || "could not read field access flags",
+            )?;
 
             field_vec.push(Field {
-                               field_id: field_id,
-                               access_flags: AccessFlags::from_bits(access_flags)
-                                   .ok_or_else(|| {
-                Error::from(ErrorKind::InvalidAccessFlags(access_flags))
-            })?,
-                           });
+                field_id: field_id,
+                access_flags: AccessFlags::from_bits(access_flags).ok_or_else(|| {
+                    Error::from(ErrorKind::InvalidAccessFlags(access_flags))
+                })?,
+            });
 
             let mut last_field_id = field_id;
             for _ in 1..field_count {
-                let (field_id_diff, _) = read_uleb128(reader)
-                    .chain_err(|| "could not read field ID")?;
-                let (access_flags, _) = read_uleb128(reader)
-                    .chain_err(|| "could not read field access flags")?;
+                let (field_id_diff, _) =
+                    read_uleb128(reader).chain_err(|| "could not read field ID")?;
+                let (access_flags, _) = read_uleb128(reader).chain_err(
+                    || "could not read field access flags",
+                )?;
 
                 // Field IDs other than the first one are given by difference.
                 last_field_id += field_id_diff;
 
                 field_vec.push(Field {
-                                   field_id: last_field_id,
-                                   access_flags: AccessFlags::from_bits(access_flags)
-                                       .ok_or_else(|| {
-                    Error::from(ErrorKind::InvalidAccessFlags(access_flags))
-                })?,
-                               });
+                    field_id: last_field_id,
+                    access_flags: AccessFlags::from_bits(access_flags).ok_or_else(|| {
+                        Error::from(ErrorKind::InvalidAccessFlags(access_flags))
+                    })?,
+                });
             }
         }
         Ok(())
     }
 
-    fn read_methods<R: Read>(reader: &mut R,
-                             method_count: u32,
-                             method_vec: &mut Vec<Method>)
-                             -> Result<()> {
+    fn read_methods<R: Read>(
+        reader: &mut R,
+        method_count: u32,
+        method_vec: &mut Vec<Method>,
+    ) -> Result<()> {
         if method_count > 0 {
             // First method's ID is given directly.
-            let (method_id, _) = read_uleb128(reader)
-                .chain_err(|| "could not read method ID")?;
-            let (access_flags, _) = read_uleb128(reader)
-                .chain_err(|| "could not read method access flags")?;
-            let (code_offset, _) = read_uleb128(reader)
-                .chain_err(|| "could not read method code offset")?;
+            let (method_id, _) = read_uleb128(reader).chain_err(
+                || "could not read method ID",
+            )?;
+            let (access_flags, _) = read_uleb128(reader).chain_err(
+                || "could not read method access flags",
+            )?;
+            let (code_offset, _) = read_uleb128(reader).chain_err(
+                || "could not read method code offset",
+            )?;
 
             let code_offset = if code_offset == 0 {
                 None
@@ -902,22 +946,24 @@ impl ClassData {
             };
 
             method_vec.push(Method {
-                                method_id: method_id,
-                                access_flags: AccessFlags::from_bits(access_flags)
-                                    .ok_or_else(|| {
-                Error::from(ErrorKind::InvalidAccessFlags(access_flags))
-            })?,
-                                code_offset: code_offset,
-                            });
+                method_id: method_id,
+                access_flags: AccessFlags::from_bits(access_flags).ok_or_else(|| {
+                    Error::from(ErrorKind::InvalidAccessFlags(access_flags))
+                })?,
+                code_offset: code_offset,
+            });
 
             let mut last_method_id = method_id;
             for _ in 1..method_count {
-                let (method_id_diff, _) = read_uleb128(reader)
-                    .chain_err(|| "could not read method ID")?;
-                let (access_flags, _) = read_uleb128(reader)
-                    .chain_err(|| "could not read method access flags")?;
-                let (code_offset, _) = read_uleb128(reader)
-                    .chain_err(|| "could not read method code offset")?;
+                let (method_id_diff, _) = read_uleb128(reader).chain_err(
+                    || "could not read method ID",
+                )?;
+                let (access_flags, _) = read_uleb128(reader).chain_err(
+                    || "could not read method access flags",
+                )?;
+                let (code_offset, _) = read_uleb128(reader).chain_err(
+                    || "could not read method code offset",
+                )?;
 
                 let code_offset = if code_offset == 0 {
                     None
@@ -929,13 +975,12 @@ impl ClassData {
                 last_method_id += method_id_diff;
 
                 method_vec.push(Method {
-                                    method_id: last_method_id,
-                                    access_flags: AccessFlags::from_bits(access_flags)
-                                        .ok_or_else(|| {
-                    Error::from(ErrorKind::InvalidAccessFlags(access_flags))
-                })?,
-                                    code_offset: code_offset,
-                                });
+                    method_id: last_method_id,
+                    access_flags: AccessFlags::from_bits(access_flags).ok_or_else(|| {
+                        Error::from(ErrorKind::InvalidAccessFlags(access_flags))
+                    })?,
+                    code_offset: code_offset,
+                });
             }
         }
         Ok(())
@@ -953,30 +998,36 @@ pub struct DebugInfo {
 impl DebugInfo {
     /// Creates a new debug information structure from a reader.
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<(DebugInfo, u32)> {
-        let (line_start, mut read) = read_uleb128(reader)
-            .chain_err(|| "could not read line_start field")?;
-        let (parameters_size, read_p) = read_uleb128(reader)
-            .chain_err(|| "could not read parameters_size field")?;
+        let (line_start, mut read) = read_uleb128(reader).chain_err(
+            || "could not read line_start field",
+        )?;
+        let (parameters_size, read_p) = read_uleb128(reader).chain_err(
+            || "could not read parameters_size field",
+        )?;
         read += read_p;
 
         let mut parameter_names = Vec::with_capacity(parameters_size as usize);
         for _ in 0..parameters_size {
-            let (name_index, read_i) = read_uleb128p1(reader)
-                .chain_err(|| "could not read parameter name index")?;
+            let (name_index, read_i) = read_uleb128p1(reader).chain_err(
+                || "could not read parameter name index",
+            )?;
             read += read_i;
             parameter_names.push(name_index);
         }
 
-        let (bytecode, read_b) = DebugBytecode::from_reader(reader)
-            .chain_err(|| "could not read debug bytecode")?;
+        let (bytecode, read_b) = DebugBytecode::from_reader(reader).chain_err(
+            || "could not read debug bytecode",
+        )?;
         read += read_b;
 
-        Ok((DebugInfo {
+        Ok((
+            DebugInfo {
                 line_start: line_start,
                 parameter_names: parameter_names,
                 bytecode: bytecode,
             },
-            read))
+            read,
+        ))
     }
 
     /// Gets the starting line of the debug information.
@@ -1003,8 +1054,9 @@ impl DebugBytecode {
         let mut bytecode = Vec::new();
         let mut read = 0;
         loop {
-            let (instruction, read_i) = DebugInstruction::from_reader(reader)
-                .chain_err(|| "could not read instruction")?;
+            let (instruction, read_i) = DebugInstruction::from_reader(reader).chain_err(
+                || "could not read instruction",
+            )?;
             read += read_i;
             bytecode.push(instruction);
 
@@ -1044,38 +1096,36 @@ enum DebugInstruction {
 impl DebugInstruction {
     fn from_reader<R: Read>(reader: &mut R) -> Result<(DebugInstruction, u32)> {
         let mut opcode = [0_u8];
-        reader
-            .read_exact(&mut opcode)
-            .chain_err(|| "could not read opcode")?;
+        reader.read_exact(&mut opcode).chain_err(
+            || "could not read opcode",
+        )?;
         let mut read = 1;
         let instruction = match opcode[0] {
             0x00_u8 => DebugInstruction::EndSequence,
             0x01_u8 => {
-                let (addr_diff, read_ad) =
-                    read_uleb128(reader).chain_err(|| {
-                            "could not read `addr_diff` for the DBG_ADVANCE_PC instruction"
-                        })?;
+                let (addr_diff, read_ad) = read_uleb128(reader).chain_err(
+                    || "could not read `addr_diff` for the DBG_ADVANCE_PC instruction",
+                )?;
                 read += read_ad;
                 DebugInstruction::AdvancePc { addr_diff: addr_diff }
             }
             0x02_u8 => {
-                let (line_diff, read_ld) =
-                    read_sleb128(reader).chain_err(|| {
-                            "could not read `line_diff` for the DBG_ADVANCE_LINE instruction"
-                        })?;
+                let (line_diff, read_ld) = read_sleb128(reader).chain_err(
+                    || "could not read `line_diff` for the DBG_ADVANCE_LINE instruction",
+                )?;
                 read += read_ld;
                 DebugInstruction::AdvanceLine { line_diff: line_diff }
             }
             0x03_u8 => {
-                let (register_num, read_rn) = read_uleb128(reader).chain_err(|| {
-                        "could not read `register_num` for the DBG_START_LOCAL instruction"
-                    })?;
-                let (name_id, read_ni) = read_uleb128p1(reader).chain_err(||{
-                            "could not read `name_id` for the DBG_START_LOCAL instruction"
-                        })?;
-                let (type_id, read_ti) = read_uleb128p1(reader).chain_err(||{
-                                "could not read `type_id` for the DBG_START_LOCAL instruction"
-                            })?;
+                let (register_num, read_rn) = read_uleb128(reader).chain_err(
+                    || "could not read `register_num` for the DBG_START_LOCAL instruction",
+                )?;
+                let (name_id, read_ni) = read_uleb128p1(reader).chain_err(
+                    || "could not read `name_id` for the DBG_START_LOCAL instruction",
+                )?;
+                let (type_id, read_ti) = read_uleb128p1(reader).chain_err(
+                    || "could not read `type_id` for the DBG_START_LOCAL instruction",
+                )?;
                 read += read_rn + read_ni + read_ti;
 
                 DebugInstruction::StartLocal {
@@ -1085,18 +1135,18 @@ impl DebugInstruction {
                 }
             }
             0x04_u8 => {
-                let (register_num, read_rn) = read_uleb128(reader).chain_err(|| {
-                        "could not read `register_num` for the DBG_START_LOCAL_EXTENDED instruction"
-                    })?;
-                let (name_id, read_ni) = read_uleb128p1(reader).chain_err(|| {
-                        "could not read `name_id` for the DBG_START_LOCAL_EXTENDED instruction"
-                    })?;
-                let (type_id, read_ti) = read_uleb128p1(reader).chain_err(|| {
-                        "could not read `type_id` for the DBG_START_LOCAL_EXTENDED instruction"
-                    })?;
-                let (sig_id, read_si) = read_uleb128p1(reader).chain_err(|| {
-                        "could not read `sig_id` for the DBG_START_LOCAL_EXTENDED instruction"
-                    })?;
+                let (register_num, read_rn) = read_uleb128(reader).chain_err(
+                    || "could not read `register_num` for the DBG_START_LOCAL_EXTENDED instruction",
+                )?;
+                let (name_id, read_ni) = read_uleb128p1(reader).chain_err(
+                    || "could not read `name_id` for the DBG_START_LOCAL_EXTENDED instruction",
+                )?;
+                let (type_id, read_ti) = read_uleb128p1(reader).chain_err(
+                    || "could not read `type_id` for the DBG_START_LOCAL_EXTENDED instruction",
+                )?;
+                let (sig_id, read_si) = read_uleb128p1(reader).chain_err(
+                    || "could not read `sig_id` for the DBG_START_LOCAL_EXTENDED instruction",
+                )?;
                 read += read_rn + read_ni + read_ti + read_si;
 
                 DebugInstruction::StartLocalExtended {
@@ -1107,26 +1157,25 @@ impl DebugInstruction {
                 }
             }
             0x05_u8 => {
-                let (register_num, read_rn) =
-                    read_uleb128(reader).chain_err(|| {
-                            "could not read `register_num` for the DBG_END_LOCAL instruction"
-                        })?;
+                let (register_num, read_rn) = read_uleb128(reader).chain_err(
+                    || "could not read `register_num` for the DBG_END_LOCAL instruction",
+                )?;
                 read += read_rn;
                 DebugInstruction::EndLocal { register_num: register_num }
             }
             0x06_u8 => {
-                let (register_num, read_rn) = read_uleb128(reader).chain_err(|| {
-                        "could not read `register_num` for the DBG_RESTART_LOCAL instruction"
-                    })?;
+                let (register_num, read_rn) = read_uleb128(reader).chain_err(
+                    || "could not read `register_num` for the DBG_RESTART_LOCAL instruction",
+                )?;
                 read += read_rn;
                 DebugInstruction::RestartLocal { register_num: register_num }
             }
             0x07_u8 => DebugInstruction::SetPrologueEnd,
             0x08_u8 => DebugInstruction::SetEpilogueBegin,
             0x09_u8 => {
-                let (name_id, read_ni) =
-                    read_uleb128(reader)
-                        .chain_err(|| "could not read `name_id` for the DBG_SET_FILE instruction")?;
+                let (name_id, read_ni) = read_uleb128(reader).chain_err(
+                    || "could not read `name_id` for the DBG_SET_FILE instruction",
+                )?;
                 read += read_ni;
                 DebugInstruction::SetFile { name_id: name_id }
             }
@@ -1153,67 +1202,70 @@ pub struct CodeItem {
 impl CodeItem {
     /// Reads a code item from the given reader.
     pub fn from_reader<R: Read, B: ByteOrder>(reader: &mut R) -> Result<CodeItem> {
-        let registers_size = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read registers size")?;
-        let ins_size = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read incoming words size")?;
-        let outs_size = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read outgoing words size")?;
-        let tries_size = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read tries size")?;
-        let debug_info_offset = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read debug information offset")?;
-        let insns_size = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read the size of the bytecode array")?;
+        let registers_size = reader.read_u16::<B>().chain_err(
+            || "could not read registers size",
+        )?;
+        let ins_size = reader.read_u16::<B>().chain_err(
+            || "could not read incoming words size",
+        )?;
+        let outs_size = reader.read_u16::<B>().chain_err(
+            || "could not read outgoing words size",
+        )?;
+        let tries_size = reader.read_u16::<B>().chain_err(
+            || "could not read tries size",
+        )?;
+        let debug_info_offset = reader.read_u32::<B>().chain_err(
+            || "could not read debug information offset",
+        )?;
+        let insns_size = reader.read_u32::<B>().chain_err(
+            || "could not read the size of the bytecode array",
+        )?;
 
         let mut insns = Vec::with_capacity(insns_size as usize);
         for _ in 0..insns_size {
-            insns.push(reader
-                           .read_u16::<B>()
-                           .chain_err(|| "could not read bytecode")?);
+            insns.push(reader.read_u16::<B>().chain_err(
+                || "could not read bytecode",
+            )?);
         }
 
         if tries_size != 0 && (insns_size & 0b1 != 0) {
             let mut padding = [0_u8; 2];
-            reader
-                .read_exact(&mut padding)
-                .chain_err(|| "could not read padding before tries")?;
+            reader.read_exact(&mut padding).chain_err(
+                || "could not read padding before tries",
+            )?;
         }
 
         let mut tries = Vec::with_capacity(tries_size as usize);
         for _ in 0..tries_size {
-            tries.push(TryItem::from_reader::<_, B>(reader)
-                           .chain_err(|| "could not read try item")?);
+            tries.push(TryItem::from_reader::<_, B>(reader).chain_err(
+                || "could not read try item",
+            )?);
         }
 
         let mut handlers = Vec::new();
         if tries_size > 0 {
-            let (handlers_size, _) = read_uleb128(reader)
-                .chain_err(|| "could not read catch handlers size")?;
+            let (handlers_size, _) = read_uleb128(reader).chain_err(
+                || "could not read catch handlers size",
+            )?;
 
             handlers.reserve_exact(handlers_size as usize);
             for _ in 0..handlers_size {
-                let (handler, _) = CatchHandler::from_reader(reader)
-                    .chain_err(|| "could not read catch handler")?;
+                let (handler, _) = CatchHandler::from_reader(reader).chain_err(
+                    || "could not read catch handler",
+                )?;
                 handlers.push(handler);
             }
         }
 
         Ok(CodeItem {
-               registers_size: registers_size,
-               ins_size: ins_size,
-               outs_size: outs_size,
-               debug_info_offset: debug_info_offset,
-               insns: insns,
-               tries: tries,
-               handlers: handlers,
-           })
+            registers_size: registers_size,
+            ins_size: ins_size,
+            outs_size: outs_size,
+            debug_info_offset: debug_info_offset,
+            insns: insns,
+            tries: tries,
+            handlers: handlers,
+        })
     }
 }
 
@@ -1228,21 +1280,21 @@ struct TryItem {
 impl TryItem {
     /// Creates a try item structure from a reader.
     fn from_reader<R: Read, B: ByteOrder>(reader: &mut R) -> Result<TryItem> {
-        let start_address = reader
-            .read_u32::<B>()
-            .chain_err(|| "could not read start address")?;
-        let insn_count = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read instruction count")?;
-        let handler_offset = reader
-            .read_u16::<B>()
-            .chain_err(|| "could not read catch handler offset")?;
+        let start_address = reader.read_u32::<B>().chain_err(
+            || "could not read start address",
+        )?;
+        let insn_count = reader.read_u16::<B>().chain_err(
+            || "could not read instruction count",
+        )?;
+        let handler_offset = reader.read_u16::<B>().chain_err(
+            || "could not read catch handler offset",
+        )?;
 
         Ok(TryItem {
-               start_address: start_address,
-               insn_count: insn_count,
-               handler_offset: handler_offset,
-           })
+            start_address: start_address,
+            insn_count: insn_count,
+            handler_offset: handler_offset,
+        })
     }
 }
 
@@ -1256,32 +1308,37 @@ struct CatchHandler {
 impl CatchHandler {
     /// Reads a catch handler from a reader.
     fn from_reader<R: Read>(reader: &mut R) -> Result<(CatchHandler, u32)> {
-        let (size, mut read) = read_sleb128(reader)
-            .chain_err(|| "could not read the catch handler size")?;
+        let (size, mut read) = read_sleb128(reader).chain_err(
+            || "could not read the catch handler size",
+        )?;
 
         let abs_size = size.abs() as usize;
         let mut handlers = Vec::with_capacity(abs_size);
         for _ in 0..abs_size {
-            let (handler_info, read_hi) = HandlerInfo::from_reader(reader)
-                .chain_err(|| "could not read handler information")?;
+            let (handler_info, read_hi) = HandlerInfo::from_reader(reader).chain_err(
+                || "could not read handler information",
+            )?;
             handlers.push(handler_info);
             read += read_hi;
         }
 
         let catch_all_addr = if size < 1 {
-            let (addr, read_ca) = read_uleb128(reader)
-                .chain_err(|| "could not read the catch all address")?;
+            let (addr, read_ca) = read_uleb128(reader).chain_err(
+                || "could not read the catch all address",
+            )?;
             read += read_ca;
             Some(addr)
         } else {
             None
         };
 
-        Ok((CatchHandler {
+        Ok((
+            CatchHandler {
                 handlers: handlers,
                 catch_all_addr: catch_all_addr,
             },
-            read))
+            read,
+        ))
     }
 }
 
@@ -1297,11 +1354,13 @@ impl HandlerInfo {
         let (type_id, read_t) = read_uleb128(reader).chain_err(|| "could not read type ID")?;
         let (addr, read_a) = read_uleb128(reader).chain_err(|| "could not read address")?;
 
-        Ok((HandlerInfo {
+        Ok((
+            HandlerInfo {
                 type_id: type_id,
                 addr: addr,
             },
-            read_t + read_a))
+            read_t + read_a,
+        ))
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,13 +5,37 @@ use std::fs;
 #[test]
 fn it_header_read() {
     let header = dalvik::Header::from_file("test.dex").unwrap();
-    assert_eq!(&[0x64, 0x65, 0x78, 0xa, 0x30, 0x33, 0x35, 0x0],
-               header.get_magic());
+    assert_eq!(
+        &[0x64, 0x65, 0x78, 0xa, 0x30, 0x33, 0x35, 0x0],
+        header.get_magic()
+    );
     assert_eq!(35, header.get_dex_version());
     assert_eq!(0xa0576d4c, header.get_checksum());
-    assert_eq!(&[0x91, 0x02, 0x73, 0x72, 0x0d, 0xda, 0xf0, 0x75, 0x5b, 0x48, 0xd8, 0x09, 0xfd,
-                 0x6a, 0x6f, 0x01, 0x8f, 0xc9, 0x29, 0x15],
-               header.get_signature());
+    assert_eq!(
+        &[
+            0x91,
+            0x02,
+            0x73,
+            0x72,
+            0x0d,
+            0xda,
+            0xf0,
+            0x75,
+            0x5b,
+            0x48,
+            0xd8,
+            0x09,
+            0xfd,
+            0x6a,
+            0x6f,
+            0x01,
+            0x8f,
+            0xc9,
+            0x29,
+            0x15,
+        ],
+        header.get_signature()
+    );
     let file_size = fs::metadata("test.dex").unwrap().len();
     assert_eq!(file_size, header.get_file_size() as u64);
     assert_eq!(0x70, header.get_header_size());


### PR DESCRIPTION
Implement `Display` trait for `AccessFlags` to be able to convert them to string.

At the moment is not exhaustive (as in match). I've been thinking on alternatives, but I didn't found a better alternative than this chain of ifs.